### PR TITLE
Remove retries for an expired transaction

### DIFF
--- a/pyqldb/driver/qldb_driver.py
+++ b/pyqldb/driver/qldb_driver.py
@@ -21,7 +21,8 @@ from pyqldb.config.retry_config import RetryConfig
 from .. import __version__
 from ..communication.session_client import SessionClient
 
-from ..errors import DriverClosedError, SessionPoolEmptyError, is_invalid_session_exception
+from ..errors import DriverClosedError, SessionPoolEmptyError, is_invalid_session_exception, \
+    is_transaction_expired_exception
 from ..session.qldb_session import QldbSession
 from ..util.atomic_integer import AtomicInteger
 
@@ -233,6 +234,8 @@ class QldbDriver:
                 with self._get_session() as session:
                     return session._execute_lambda(query_lambda, retry_config, context)
             except ClientError as ce:
+                if is_transaction_expired_exception(ce):
+                    raise ce
                 if is_invalid_session_exception(ce):
                     pass
                 else:

--- a/pyqldb/errors/__init__.py
+++ b/pyqldb/errors/__init__.py
@@ -9,6 +9,8 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
+import re
+
 
 class IllegalStateError(Exception):
     pass
@@ -92,6 +94,24 @@ def is_invalid_session_exception(e):
     """
     is_invalid_session = e.response['Error']['Code'] == 'InvalidSessionException'
     return is_invalid_session
+
+
+def is_transaction_expired_exception(e):
+    """
+    Does this exception denote that a transaction has expired?
+
+    :type e: :py:class:`botocore.exceptions.ClientError`
+    :param e: The ClientError caught.
+
+    :rtype: bool
+    :return: True if the exception denote that a transaction has expired. False otherwise.
+    """
+    is_invalid_session = e.response['Error']['Code'] == 'InvalidSessionException'
+
+    if "Message" in  e.response["Error"]:
+        return is_invalid_session and re.search("Transaction .* has expired", e.response["Error"]["Message"])
+
+    return False
 
 
 def is_retriable_exception(e):

--- a/tests/integration/test_statement_execution.py
+++ b/tests/integration/test_statement_execution.py
@@ -8,6 +8,8 @@
 # or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
+from time import sleep
+
 import pytest
 from unittest import TestCase
 
@@ -554,6 +556,14 @@ class TestStatementExecution(TestCase):
         # When.
         self.assertRaises(ClientError, self.qldb_driver.execute_lambda, lambda txn: txn.execute_statement(query))
 
+    def test_error_when_transaction_expires(self):
+        # Given.
+        def query_lambda(txn):
+            # wait for the transaction to expire
+            sleep(40)
+
+        # When.
+        self.assertRaises(ClientError, self.qldb_driver.execute_lambda, lambda executor: query_lambda(executor))
 
 def create_ion_values():
     ion_values = list()

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -12,7 +12,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from pyqldb.errors import is_occ_conflict_exception, is_invalid_session_exception, is_retriable_exception, \
-    is_bad_request_exception
+    is_bad_request_exception, is_transaction_expired_exception
 
 
 class TestErrors(TestCase):
@@ -26,6 +26,19 @@ class TestErrors(TestCase):
     def test_is_bad_request_exception_false(self, mock_client_error):
         mock_client_error.response = {'Error': {'Code': 'NotBadRequestException'}}
         self.assertFalse(is_bad_request_exception(mock_client_error))
+
+
+    @patch('botocore.exceptions.ClientError')
+    def test_is_transaction_expired_exception(self, mock_client_error):
+        mock_client_error.response = {'Error': {'Code': 'InvalidSessionException',
+                                                'Message': 'Transaction xyz has expired'}}
+        self.assertTrue(is_transaction_expired_exception(mock_client_error))
+
+    @patch('botocore.exceptions.ClientError')
+    def test_is_bad_request_exception_false(self, mock_client_error):
+        mock_client_error.response = {'Error': {'Code': 'InvalidSessionException',
+                                                'Message': 'Transaction xyz has not expired'}}
+        self.assertFalse(is_transaction_expired_exception(mock_client_error))
 
     @patch('botocore.exceptions.ClientError')
     def test_is_occ_conflict_exception_true(self, mock_client_error):


### PR DESCRIPTION
Earlier a transaction used to be retried
infinite number of times. We don't see value
in retrying a transaction as it is which outlived
the regular transaction life. With this change, a
transaction will not be retried if it failed due to
a transaction expiry and the execption will be bubbled
all the way to the application code using the driver.